### PR TITLE
Use file metadata column instead of `input_file_name`

### DIFF
--- a/notebooks/02. Building Delta Live Tables Pipelines-SQL.sql
+++ b/notebooks/02. Building Delta Live Tables Pipelines-SQL.sql
@@ -14,7 +14,7 @@ TBLPROPERTIES ("quality" = "bronze")
 AS (
       SELECT
       *,
-      input_file_name() AS inputFileName
+      _metadata.file_path AS inputFileName
       FROM cloud_files( '${data_source_path}', 'csv', 
             map("schema", "InvoiceNo STRING, StockCode STRING, Description STRING, Quantity FLOAT, InvoiceDate STRING, UnitPrice FLOAT, CustomerID STRING, Country STRING",  
             "header", "true"))


### PR DESCRIPTION
`input_file_name` isn't supported in the Unity Catalog, so it's better to use file metadata column that works with Unity Catalog